### PR TITLE
registration check and exclusion of gorm-related-calls into metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ These all have the following labels:
 - `database`: the name of the database
 - `driver`: the driver for the database (e.g. pq)
 - `status`: fail or success (only for query-related metrics)
+
+## Exclusions to monitoring
+
+If you want certain gorm-related queries to not be monitored and have metrics, there is a special field you can set.
+
+```go
+db.dbResult.Set("gormmetrics", false)
+```
+
+This will make sure whatever happens next is not part of the metrics-data.
+The only value for which exclusions are applicable, is the boolean 'false'.
+Be sure to un-set this flag after the exclusion-part in your code.
+
+```go
+db.dbResult.Set("gormmetrics", true)
+```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These all have the following labels:
 If you want certain gorm-related queries to not be monitored and have metrics, there is a special field you can set.
 
 ```go
-db.dbResult.Set("gormmetrics", false)
+db.dbResult.Set(gormetrics.DisableGormMetricsDatabaseKey, false)
 ```
 
 This will make sure whatever happens next is not part of the metrics-data.
@@ -66,5 +66,5 @@ The only value for which exclusions are applicable, is the boolean 'false'.
 Be sure to un-set this flag after the exclusion-part in your code.
 
 ```go
-db.dbResult.Set("gormmetrics", true)
+db.dbResult.Set(gormetrics.DisableGormMetricsDatabaseKey, true)
 ```

--- a/callback.go
+++ b/callback.go
@@ -82,7 +82,7 @@ func (h *callbackHandler) setStartTime(db *gorm.DB) {
 }
 
 func checkRegistration(db *gorm.DB) bool {
-	value, ok := db.Get("gormmetrics-enabled")
+	value, ok := db.Get(DisableGormMetricsDatabaseKey)
 
 	// If value is not specifically set, it should be registered
 	if !ok {

--- a/callback.go
+++ b/callback.go
@@ -16,8 +16,9 @@ package gormetrics
 
 import (
 	"fmt"
-	"gorm.io/gorm"
 	"time"
+
+	"gorm.io/gorm"
 
 	"github.com/pkg/errors"
 
@@ -80,24 +81,51 @@ func (h *callbackHandler) setStartTime(db *gorm.DB) {
 	db.Set("timeStart", time.Now())
 }
 
+func checkRegistration(db *gorm.DB) bool {
+	value, ok := db.Get("gormmetrics-enabled")
+
+	// If value is not specifically set, it should be registered
+	if !ok {
+		return true
+	}
+
+	valueBool, ok := value.(bool)
+
+	// If value was not a boolean, it should be registered
+	if !ok {
+		return true
+	}
+
+	// If all fetching and casting worked, return the actual value present
+	return valueBool
+}
+
 func (h *callbackHandler) afterCreate(db *gorm.DB) {
-	h.updateCounterVectors(db, h.counters.creates)
-	h.updateHistogramVectors(db, h.counters.createsDuration)
+	if checkRegistration(db) {
+		h.updateCounterVectors(db, h.counters.creates)
+		h.updateHistogramVectors(db, h.counters.createsDuration)
+	}
 }
 
 func (h *callbackHandler) afterDelete(db *gorm.DB) {
-	h.updateCounterVectors(db, h.counters.deletes)
-	h.updateHistogramVectors(db, h.counters.deletesDuration)
+	if checkRegistration(db) {
+		h.updateCounterVectors(db, h.counters.deletes)
+		h.updateHistogramVectors(db, h.counters.deletesDuration)
+	}
 }
 
 func (h *callbackHandler) afterQuery(db *gorm.DB) {
-	h.updateCounterVectors(db, h.counters.queries)
-	h.updateHistogramVectors(db, h.counters.queriesDuration)
+	if checkRegistration(db) {
+		h.updateCounterVectors(db, h.counters.queries)
+		h.updateHistogramVectors(db, h.counters.queriesDuration)
+	}
 }
 
 func (h *callbackHandler) afterUpdate(db *gorm.DB) {
-	h.updateCounterVectors(db, h.counters.updates)
-	h.updateHistogramVectors(db, h.counters.updatesDuration)
+	if checkRegistration(db) {
+		h.updateCounterVectors(db, h.counters.updates)
+		h.updateHistogramVectors(db, h.counters.updatesDuration)
+	}
 }
 
 // updateCounterVectors registers one or more of prometheus.CounterVec to increment

--- a/callback.go
+++ b/callback.go
@@ -81,6 +81,7 @@ func (h *callbackHandler) setStartTime(db *gorm.DB) {
 	db.Set("timeStart", time.Now())
 }
 
+// checkRegistration will check if the metrics should be registered
 func checkRegistration(db *gorm.DB) bool {
 	value, ok := db.Get(DisableGormMetricsDatabaseKey)
 

--- a/opts.go
+++ b/opts.go
@@ -14,6 +14,10 @@
 
 package gormetrics
 
+const (
+	DisableGormMetricsDatabaseKey = "gormmetrics-enabled"
+)
+
 // RegisterOpt if a function that operates on pluginOpts, configuring one or
 // more parameters of the plugin options.
 type RegisterOpt func(o *pluginOpts)

--- a/opts.go
+++ b/opts.go
@@ -15,6 +15,7 @@
 package gormetrics
 
 const (
+	// DisableGormMetricsDatabaseKey can be set on the *gorm.DB object to (temporarily) disable metrics on a particular query
 	DisableGormMetricsDatabaseKey = "gormmetrics-enabled"
 )
 


### PR DESCRIPTION
Allow an exclusion to the regular gorm-metrics.

Sometimes you do not want a subset of calls (which might be happening way too often, are irrelevant, are scheduled to run every few miliseconds, ...).

This now allows to exclude this so they are not part of the metrics-data.